### PR TITLE
Refactor include author

### DIFF
--- a/_includes/author-link.html
+++ b/_includes/author-link.html
@@ -1,3 +1,3 @@
-{% assign authorId = include.data-id %}
-{% assign author = site.data.authors.authors[authorId] %}
-<a rel="author" href="{{ site.baseurl }}/{{ authorId }}">{{ author.name }}</a>
+{% assign author-id = include.author-id %}
+{% assign author = site.data.authors.authors[author-id] %}
+<a rel="author" href="{{ site.baseurl }}/{{ author-id }}">{{ author.name }}</a>

--- a/_includes/author-link.html
+++ b/_includes/author-link.html
@@ -1,0 +1,3 @@
+{% assign authorId = include.data-id %}
+{% assign author = site.data.authors.authors[authorId] %}
+<a rel="author" href="{{ site.baseurl }}/{{ authorId }}">{{ author.name }}</a>

--- a/_includes/author_summary.html
+++ b/_includes/author_summary.html
@@ -1,6 +1,8 @@
+{% assign author-id = include.author-id %}
+{% assign author = site.data.authors.authors[author-id] %}
 <div class="author-information cell">
-  <img src="{{ site.baseurl }}/{{ authorUsername }}/{{ author.picture }}" alt="{{ author.name }}"/>
-  <a rel="author" href="{{ site.baseurl }}/{{ authorUsername }}">{{ author.name }}</a>
+  <img src="{{ site.baseurl }}/{{ author-id }}/{{ author.picture }}" alt="{{ author.name }}"/>
+  <a rel="author" href="{{ site.baseurl }}/{{ author-id }}">{{ author.name }}</a>
 </div>
 <div class="cell">
   {{ author.author-summary }}

--- a/_layouts/default_post.html
+++ b/_layouts/default_post.html
@@ -80,11 +80,9 @@ layout: default
       <div class="author-information cell medium-10 small-9 hide-for-large">
         {% include author_picture.html %}
         <a rel="author" href="{{ site.baseurl }}/{{ authorUsername }}">{{ author.name }}</a>
-         {% for contributorId in page.contributors %}
-             {% assign contributor = site.data.authors.authors[contributorId] %}
-             {% assign contributorUsername = contributorId %}
-            , <a rel="author" href="{{ site.baseurl }}/{{ contributorUsername }}">{{ contributor.name }}</a>
-         {% endfor %}
+          {% for contributorId in page.contributors %}
+            {% include author-link.html data-id=contributorId %}
+          {% endfor %}
       </div>
       {% include social.html %}
     </div>

--- a/_layouts/default_post.html
+++ b/_layouts/default_post.html
@@ -79,9 +79,9 @@ layout: default
     <div class="cell primary-meta-data large-1 large-offset-1 grid-x">
       <div class="author-information cell medium-10 small-9 hide-for-large">
         {% include author_picture.html %}
-        <a rel="author" href="{{ site.baseurl }}/{{ authorUsername }}">{{ author.name }}</a>
-          {% for contributorId in page.contributors %}
-            {% include author-link.html data-id=contributorId %}
+        <a rel="author" href="{{ site.baseurl }}/{{ authorUsername }}">{{ author.name }}</a>{%
+          for contributorId in page.contributors %},
+            {% include author-link.html author-id=contributorId %}
           {% endfor %}
       </div>
       {% include social.html %}
@@ -103,13 +103,9 @@ layout: default
       {% include recruitment.html page=page %}
     </div>
     <div class="side-lists cell large-3 large-offset-1 show-for-large grid-padding-y">
-      {% assign author = site.data.authors.authors[page.author] %}
-      {% assign authorUsername = page.author %}
-      {% include author_summary.html %}
+      {% include author_summary.html author-id=page.author %}
       {% for contributorId in page.contributors %}
-        {% assign author = site.data.authors.authors[contributorId] %}
-        {% assign authorUsername = contributorId %}
-        {% include author_summary.html %}
+        {% include author_summary.html author-id=contributorId %}
       {% endfor %}
       {% include category_list.html selectedIndex=0 %}
       <div class="back cell">

--- a/_layouts/video_post.html
+++ b/_layouts/video_post.html
@@ -79,11 +79,9 @@ layout: default
 
     </div>
     <div class="side-lists cell large-3 large-offset-1 show-for-large grid-padding-y">
-      {% include author_summary.html %}
+      {% include author_summary.html author-id=page.author %}
       {% for contributorId in page.contributors %}
-        {% assign author = site.data.authors.authors[contributorId] %}
-        {% assign authorUsername = contributorId %}
-        {% include author_summary.html %}
+        {% include author_summary.html author-id=contributorId %}
       {% endfor %}
       {% include category_list.html selectedIndex=0 %}
       <div class="back cell">


### PR DESCRIPTION
Original goal was to allow the contents of https://blog.scottlogic.com/2019/07/23/Testing-WebSockets-for-beginners.html
to 
- `my colleague {% include author-link.html data-id="hwilliams" %},`

instead of 
- `my colleague [Herb Williams]({{site.baseurl}}/hwilliams),`

So created **_includes/author-link.html**.

On consideration, it seemed a better design to keep markdown content and layout includes separate, so didn't apply to the original post. However, the associated refactoring to use parameters with the new include file reduced some boiler plate from the original files, so seemed worth keeping and doing the related author-summary.html as well.

On testing the changes I noticed that, when you reduce the width of the display, the alternative list of contributors was being rendered with a space before the comma in the list, so fixed that as well.

Before:
<img width="179" alt="author-link-commas-before" src="https://github.com/ithake/blog-slogic/assets/5435709/51338fef-a55f-40b8-807c-70c5fbb022c1">

After:
<img width="182" alt="author-link-commas-after" src="https://github.com/ithake/blog-slogic/assets/5435709/73d0ded4-8501-474b-806d-0f62ddaf011d">


Please add a direct link to your post here:

https://<your-username>.github.io/blog/<post-url>

Have you (please tick each box to show completion):

 - [ ] Added your blog post to a single category?
 - [ ] Added a brief summary for your post? Summaries should be roughly two sentences in length and give potential readers a good idea of the contents of your post.
 - [ ] Checked that the build passes?
 - [ ] Checked your spelling (you can use `npm spellcheck` if that's your thing)
 - [ ] Ensured that your author profile contains a profile image, and a brief description of yourself? (make it more interesting than just your job title!)
 - [ ] Optimised any images in your post? They should be less than 100KBytes as a general guide.

Posts are approved based on their category. replace `(at)` with `@` to notify them!

 - Tech - Colin Eberhardt - (at)ColinEberhardt
 - Cloud - Colin Eberhardt - (at)ColinEberhardt
 - Delivery - Matt Phillips - (at)scottlogicmphillips
 - UX - Graham Odds - (at)godds
 - People - Graham Odds - (at)godds
 - Testing - Laurence Pisani - (at)lpisani-SL
